### PR TITLE
Redesign dashboard UI: dark mode, professional polish & layout fit fixes

### DIFF
--- a/go-rewrite/static/battery.html
+++ b/go-rewrite/static/battery.html
@@ -4,6 +4,19 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>BMW CarData - Fleet Battery Health</title>
+    <!-- Set theme before any paint to avoid flash of incorrect theme -->
+    <script>
+        (function() {
+            try {
+                var saved = localStorage.getItem('bmw-theme');
+                var theme = saved || (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+                document.documentElement.setAttribute('data-theme', theme);
+            } catch (e) {
+                document.documentElement.setAttribute('data-theme', 'light');
+            }
+        })();
+    </script>
+    <script src="/static/js/theme.js"></script>
     <!-- CSS will be loaded dynamically with cache busting -->
     <!-- Include Plotly.js -->
     <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
@@ -47,11 +60,12 @@
     <style>
         /* Additional styles specific to the battery health page */
         .battery-health-container {
-            background-color: white;
-            border-radius: 12px;
+            background-color: var(--card-bg);
+            border: 1px solid var(--border);
+            border-radius: 14px;
             padding: 20px;
             margin-bottom: 20px;
-            box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+            box-shadow: var(--shadow-sm);
         }
         
         .filter-section {
@@ -60,14 +74,18 @@
             gap: 15px;
             margin-bottom: 20px;
             padding: 15px;
-            background-color: #f8f9fa;
+            background-color: var(--surface-2);
+            border: 1px solid var(--border);
             border-radius: 8px;
+            color: var(--text);
         }
         
         .filter-section select {
             padding: 8px 12px;
-            border-radius: 4px;
-            border: 1px solid #ddd;
+            border-radius: 6px;
+            border: 1px solid var(--border-strong);
+            background-color: var(--card-bg);
+            color: var(--text);
             font-size: 14px;
             min-width: 200px;
         }
@@ -75,7 +93,7 @@
         .chart-info {
             margin-bottom: 15px;
             font-size: 14px;
-            color: #666;
+            color: var(--muted);
         }
         
         .legend-item {
@@ -83,6 +101,7 @@
             align-items: center;
             margin-right: 15px;
             margin-bottom: 10px;
+            color: var(--text);
         }
         
         .legend-color {
@@ -94,15 +113,28 @@
         
         .battery-info-box {
             padding: 15px;
-            background-color: #f8f9fa;
-            border-left: 4px solid #3498db;
+            background-color: var(--surface-2);
+            border-left: 4px solid var(--accent);
+            border-radius: 8px;
             margin-bottom: 20px;
+            color: var(--text);
+        }
+
+        .notice {
+            text-align: center;
+            color: var(--muted);
+            margin: 20px 0;
+            font-style: italic;
         }
     </style>
 </head>
 <body>
     <div class="container">
         <header>
+            <button id="theme-toggle" class="theme-toggle" type="button" aria-label="Toggle dark mode" title="Toggle dark mode">
+                <span class="icon-moon" aria-hidden="true">🌙</span>
+                <span class="icon-sun" aria-hidden="true">☀️</span>
+            </button>
             <h1>BMW CarData - Fleet Battery Health</h1>
             <nav class="main-nav">
                 <ul>
@@ -272,9 +304,10 @@
         }
         
         function renderBatteryHealthChart(batteryData) {
+            window.__batteryData = batteryData;
             if (!batteryData || !Array.isArray(batteryData) || batteryData.length === 0) {
                 document.getElementById('battery-health-chart').innerHTML = 
-                    '<div style="text-align:center;padding:40px;color:#666;">No battery health data available</div>';
+                    '<div style="text-align:center;padding:40px;color:var(--muted);">No battery health data available</div>';
                 return;
             }
             
@@ -362,18 +395,26 @@
                 hoverinfo: 'text'
             };
             
-            // Define layout
+            // Define layout (theme-aware so the chart re-skins in dark mode)
+            const theme = (window.BMWTheme && window.BMWTheme.plotlyLayout)
+                ? window.BMWTheme.plotlyLayout()
+                : {};
             const layout = {
+                paper_bgcolor: theme.paper_bgcolor,
+                plot_bgcolor: theme.plot_bgcolor,
+                font: theme.font,
                 title: {
                     text: 'Fleet Battery Capacity Over Kilometers Driven',
-                    font: { size: 20 }
+                    font: { size: 20, color: theme.title && theme.title.font ? theme.title.font.color : undefined }
                 },
                 xaxis: {
+                    ...(theme.xaxis || {}),
                     title: 'Mileage (km)',
                     tickformat: ',d',
                     autorange: true  // Let Plotly determine the best range
                 },
                 yaxis: {
+                    ...(theme.yaxis || {}),
                     title: 'Estimated Capacity (kWh)',
                     range: [
                         Math.min(...rawY, ...trendY) * 0.95,  // Less aggressive scaling for better visualization
@@ -382,6 +423,7 @@
                 },
                 hovermode: 'closest',
                 legend: {
+                    ...(theme.legend || {}),
                     orientation: 'h',
                     y: -0.2
                 },
@@ -392,6 +434,14 @@
             // Create the plot
             Plotly.newPlot('battery-health-chart', [rawTrace, trendTrace], layout);
         }
+
+        // Re-render the battery chart when the theme toggles so its background,
+        // axes and fonts follow light/dark mode.
+        window.addEventListener('bmwthemechange', function() {
+            if (window.__batteryData) {
+                renderBatteryHealthChart(window.__batteryData);
+            }
+        });
         
         function showError(message) {
             // Create an error message element

--- a/go-rewrite/static/css/nav.css
+++ b/go-rewrite/static/css/nav.css
@@ -1,17 +1,18 @@
-/* Navigation styles */
+/* Navigation — understated segmented tabs */
 .main-nav {
-    margin: 20px auto 30px;
+    margin: 0;
     display: flex;
-    justify-content: center;
 }
 
 .main-nav ul {
     list-style-type: none;
     display: flex;
-    background-color: #fff;
-    border-radius: 30px;
-    padding: 5px;
-    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+    gap: 2px;
+    padding: 4px;
+    margin: 0;
+    background-color: var(--surface-2, #f8f9fa);
+    border: 1px solid var(--border, #e6e9ee);
+    border-radius: var(--radius, 8px);
 }
 
 .main-nav li {
@@ -21,50 +22,45 @@
 
 .main-nav a {
     display: block;
-    padding: 10px 20px;
+    padding: 7px 14px;
     text-decoration: none;
-    color: #555;
+    color: var(--muted, #6b7785);
     font-weight: 500;
-    border-radius: 25px;
-    transition: all 0.3s ease;
+    font-size: 14px;
+    border-radius: var(--radius-sm, 6px);
+    transition: color 0.2s ease, background-color 0.2s ease;
+    white-space: nowrap;
 }
 
 .main-nav li.active a {
-    background: linear-gradient(45deg, #3498db, #1abc9c);
-    color: white;
-    box-shadow: 0 4px 8px rgba(52, 152, 219, 0.3);
+    background-color: var(--card-bg, #fff);
+    color: var(--accent, #3498db);
+    font-weight: 600;
+    box-shadow: var(--shadow-sm, 0 1px 2px rgba(0,0,0,0.06));
 }
 
 .main-nav a:hover:not(.active) {
-    background-color: #f0f0f0;
-    color: #3498db;
+    color: var(--text, #2c3e50);
 }
 
 /* Responsive navigation */
 @media (max-width: 768px) {
-    .main-nav ul {
-        flex-direction: column;
-        border-radius: 15px;
+    .main-nav {
         width: 100%;
     }
-    
-    .main-nav li {
+
+    .main-nav ul {
         width: 100%;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+
+    .main-nav li {
+        flex: 1 1 auto;
         text-align: center;
     }
-    
+
     .main-nav a {
-        border-radius: 0;
-        padding: 15px;
-    }
-    
-    .main-nav li:first-child a {
-        border-top-left-radius: 15px;
-        border-top-right-radius: 15px;
-    }
-    
-    .main-nav li:last-child a {
-        border-bottom-left-radius: 15px;
-        border-bottom-right-radius: 15px;
+        padding: 9px 10px;
     }
 }

--- a/go-rewrite/static/css/styles.css
+++ b/go-rewrite/static/css/styles.css
@@ -1,3 +1,63 @@
+/* ==========================================================================
+   BMW CarData Dashboard — Design tokens & theming
+   ========================================================================== */
+:root {
+    /* Brand accents (shared across themes) */
+    --accent: #3498db;
+    --accent-2: #1abc9c;
+    --accent-strong: #2980b9;
+    --accent-2-strong: #16a085;
+    --accent-grad: linear-gradient(45deg, #3498db, #1abc9c);
+    --accent-grad-strong: linear-gradient(45deg, #2980b9, #16a085);
+
+    /* Semantic (kept identical across themes — they read well on both) */
+    --success: #2ecc71;
+    --warning: #f39c12;
+    --danger: #e74c3c;
+
+    /* Light theme surfaces & text */
+    --bg: #f4f6f9;
+    --bg-accent: radial-gradient(1200px 600px at 50% -10%, rgba(52,152,219,0.10), transparent 60%);
+    --card-bg: #ffffff;
+    --surface-2: #f8f9fa;
+    --track: #eef1f4;
+    --text: #2c3e50;
+    --heading: #2c3e50;
+    --muted: #6b7785;
+    --border: #e6e9ee;
+    --border-strong: #d4dae1;
+
+    /* Effects */
+    --radius-sm: 6px;
+    --radius: 8px;
+    --radius-lg: 12px;
+    --shadow-sm: 0 1px 2px rgba(17, 24, 39, 0.04), 0 1px 3px rgba(17, 24, 39, 0.06);
+    --shadow-md: 0 4px 12px rgba(17, 24, 39, 0.06);
+    --shadow-lg: 0 12px 28px rgba(17, 24, 39, 0.08);
+    --ring: rgba(52, 152, 219, 0.25);
+
+    --maxw: 1400px;
+    --space: 20px;
+    --transition: 0.25s ease;
+}
+
+html[data-theme="dark"] {
+    --bg: #0e1420;
+    --bg-accent: radial-gradient(1200px 600px at 50% -10%, rgba(52,152,219,0.16), transparent 60%);
+    --card-bg: #161e2c;
+    --surface-2: #1b2434;
+    --track: #243044;
+    --text: #e6edf5;
+    --heading: #f1f6fb;
+    --muted: #93a4ba;
+    --border: #28344a;
+    --border-strong: #34425c;
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3), 0 1px 3px rgba(0, 0, 0, 0.25);
+    --shadow-md: 0 4px 14px rgba(0, 0, 0, 0.4);
+    --shadow-lg: 0 14px 32px rgba(0, 0, 0, 0.5);
+    --ring: rgba(52, 152, 219, 0.45);
+}
+
 /* Base styles */
 * {
     box-sizing: border-box;
@@ -8,60 +68,156 @@
 
 body {
     line-height: 1.6;
-    color: #333;
-    background-color: #f8f9fa;
+    color: var(--text);
+    background-color: var(--bg);
+    background-image: var(--bg-accent);
+    background-repeat: no-repeat;
+    background-attachment: fixed;
     font-size: 16px;
+    transition: background-color var(--transition), color var(--transition);
 }
 
 .container {
-    max-width: 1400px;
+    max-width: var(--maxw);
     margin: 0 auto;
     padding: 20px;
 }
 
 h1, h2, h3, h4 {
-    color: #3498db;
+    color: var(--heading);
     margin-bottom: 15px;
     font-weight: 600;
+    letter-spacing: -0.01em;
 }
 
 h1 {
-    text-align: center;
-    margin: 25px 0;
-    font-size: 32px;
-    background: linear-gradient(45deg, #3498db, #1abc9c);
-    background-clip: text;
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    color: transparent;
-    position: relative;
+    margin: 0;
+    font-size: 19px;
+    font-weight: 600;
+    line-height: 1.25;
+    color: var(--heading);
+    letter-spacing: -0.01em;
+    display: flex;
+    align-items: center;
+    gap: 12px;
 }
 
-h1::after {
+h1::before {
     content: '';
-    display: block;
-    width: 100px;
-    height: 3px;
-    background: linear-gradient(45deg, #3498db, #1abc9c);
-    margin: 10px auto 0;
-    border-radius: 3px;
+    width: 4px;
+    align-self: stretch;
+    min-height: 22px;
+    border-radius: 2px;
+    background: var(--accent-grad);
+    flex: 0 0 auto;
 }
+
+/* Header — single-row app bar */
+header {
+    position: relative;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 14px 20px;
+    padding: 14px 2px;
+    margin-bottom: 24px;
+    border-bottom: 1px solid var(--border);
+}
+
+header > h1 {
+    order: 0;
+    flex: 0 1 auto;
+    margin-right: auto;
+}
+
+header > .main-nav {
+    order: 1;
+}
+
+header > .theme-toggle {
+    order: 2;
+}
+
+header > #disclaimer,
+header > #energy-data-warning,
+header > .notice {
+    order: 3;
+    flex: 1 0 100%;
+}
+
+@media (max-width: 768px) {
+    header > .theme-toggle {
+        order: 1;
+    }
+
+    header > .main-nav {
+        order: 2;
+        flex: 1 0 100%;
+    }
+}
+
+/* Theme toggle */
+.theme-toggle {
+    position: static;
+    z-index: 20;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 38px;
+    height: 38px;
+    padding: 0;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background-color: var(--card-bg);
+    color: var(--text);
+    box-shadow: var(--shadow-sm);
+    cursor: pointer;
+    font-size: 16px;
+    line-height: 1;
+    transition: border-color var(--transition), background-color var(--transition);
+}
+
+.theme-toggle:hover {
+    border-color: var(--accent);
+    background-color: var(--surface-2);
+}
+
+.theme-toggle .icon-sun { display: none; }
+.theme-toggle .icon-moon { display: inline; }
+html[data-theme="dark"] .theme-toggle .icon-sun { display: inline; }
+html[data-theme="dark"] .theme-toggle .icon-moon { display: none; }
 
 /* Disclaimer and warning */
 .disclaimer {
-    text-align: center;
-    color: red;
-    font-weight: bold;
-    margin-bottom: 20px;
-    white-space: pre;
+    text-align: left;
+    color: var(--muted);
+    font-weight: 400;
+    font-size: 12.5px;
+    line-height: 1.5;
+    margin: 4px 0 0;
+    white-space: normal;
 }
 
 .warning {
     text-align: center;
-    color: orange;
-    font-weight: bold;
+    color: var(--warning);
+    font-weight: 500;
     margin: 10px 0;
     display: none;
+}
+
+/* Reusable panel/card surface */
+.upload-section,
+.date-filter,
+.providers,
+.soc-stats,
+.session-selector {
+    background-color: var(--card-bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow-sm);
+    padding: 22px;
+    margin-bottom: 26px;
 }
 
 /* File upload styles */
@@ -69,7 +225,6 @@ h1::after {
     display: flex;
     flex-direction: column;
     align-items: center;
-    margin-bottom: 30px;
 }
 
 .upload-container {
@@ -85,14 +240,14 @@ h1::after {
     display: flex;
     align-items: center;
     padding: 10px 15px;
-    background-color: rgba(52, 152, 219, 0.1);
+    background-color: color-mix(in srgb, var(--accent) 10%, transparent);
     border-radius: 8px;
-    border: 1px solid rgba(52, 152, 219, 0.2);
-    transition: all 0.3s ease;
+    border: 1px solid color-mix(in srgb, var(--accent) 22%, transparent);
+    transition: all var(--transition);
 }
 
 .consent-checkbox:hover {
-    background-color: rgba(52, 152, 219, 0.15);
+    background-color: color-mix(in srgb, var(--accent) 16%, transparent);
 }
 
 .consent-checkbox input[type="checkbox"] {
@@ -100,18 +255,33 @@ h1::after {
     width: 18px;
     height: 18px;
     cursor: pointer;
+    accent-color: var(--accent);
 }
 
 .consent-checkbox label {
     font-size: 14px;
     cursor: pointer;
+    color: var(--text);
+}
+
+#model-selector label {
+    color: var(--text);
+}
+
+#model-selector select {
+    color: var(--text);
+    background-color: var(--surface-2);
+    border: 1px solid var(--border-strong);
+    border-radius: 8px;
+    padding: 8px 10px;
+    margin-top: 6px;
 }
 
 /* Tooltip styling */
 .tooltip {
     position: relative;
     display: inline-block;
-    color: #3498db;
+    color: var(--accent);
     cursor: help;
     margin-left: 5px;
     font-size: 14px;
@@ -123,15 +293,16 @@ h1::after {
     bottom: 100%;
     left: 50%;
     transform: translateX(-50%);
-    background-color: rgba(0, 0, 0, 0.8);
+    background-color: rgba(0, 0, 0, 0.85);
     color: white;
     padding: 8px 12px;
     border-radius: 6px;
-    white-space: nowrap;
+    white-space: normal;
     font-size: 12px;
     z-index: 100;
     width: max-content;
     max-width: 300px;
+    line-height: 1.4;
 }
 
 .file-input {
@@ -146,45 +317,45 @@ h1::after {
 .file-label {
     width: 100%;
     height: 100%;
-    border: 2px dashed #3498db;
-    border-radius: 12px;
+    border: 2px dashed var(--accent);
+    border-radius: var(--radius);
     display: flex;
     justify-content: center;
     align-items: center;
     cursor: pointer;
     text-align: center;
-    transition: all 0.3s ease;
+    transition: all var(--transition);
     background-size: cover;
     font-weight: 500;
-    box-shadow: 0 4px 12px rgba(0,0,0,0.05);
-    background-color: rgba(52, 152, 219, 0.05);
+    color: var(--text);
+    box-shadow: var(--shadow-sm);
+    background-color: color-mix(in srgb, var(--accent) 6%, transparent);
+    padding: 0 16px;
 }
 
 .file-label:hover {
-    background-color: rgba(52, 152, 219, 0.1);
+    background-color: color-mix(in srgb, var(--accent) 12%, transparent);
     border-style: solid;
-    box-shadow: 0 6px 16px rgba(0,0,0,0.1);
-    transform: translateY(-2px);
+    box-shadow: var(--shadow-sm);
 }
 
 .button {
-    background: linear-gradient(45deg, #3498db, #1abc9c);
+    background: var(--accent-grad);
     color: white;
     border: none;
-    border-radius: 8px;
+    border-radius: var(--radius-sm);
     padding: 10px 20px;
     cursor: pointer;
     margin: 8px;
-    transition: all 0.3s ease;
+    transition: filter var(--transition), box-shadow var(--transition);
     font-weight: 500;
-    box-shadow: 0 4px 8px rgba(52, 152, 219, 0.3);
+    box-shadow: var(--shadow-sm);
     font-size: 14px;
 }
 
 .button:hover {
-    background: linear-gradient(45deg, #2980b9, #16a085);
-    transform: translateY(-2px);
-    box-shadow: 0 6px 12px rgba(52, 152, 219, 0.4);
+    filter: brightness(1.05);
+    box-shadow: var(--shadow-md);
 }
 
 /* Date filter section */
@@ -192,21 +363,44 @@ h1::after {
     display: flex;
     flex-direction: column;
     align-items: center;
-    margin-bottom: 20px;
     width: 100%;
+}
+
+.date-filter > label {
+    color: var(--text);
+    font-weight: 500;
+    margin-bottom: 6px;
 }
 
 .date-picker {
     display: flex;
     align-items: center;
     margin-bottom: 10px;
+    flex-wrap: wrap;
+    justify-content: center;
 }
 
 .date-picker input {
-    margin: 0 10px;
-    padding: 8px;
-    border: 2px solid #3498db;
-    border-radius: 5px;
+    margin: 6px 10px;
+    padding: 8px 10px;
+    border: 2px solid var(--border-strong);
+    border-radius: 8px;
+    background-color: var(--surface-2);
+    color: var(--text);
+    transition: border-color var(--transition), box-shadow var(--transition);
+}
+
+.date-picker input:focus {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px var(--ring);
+    outline: none;
+}
+
+/* Section eyebrow heading helper */
+.section-title {
+    font-size: 20px;
+    margin-bottom: 18px;
+    color: var(--heading);
 }
 
 /* Gauge charts */
@@ -217,34 +411,45 @@ h1::after {
 .gauge-row {
     display: flex;
     justify-content: space-around;
-    margin-bottom: 30px;
+    margin-bottom: 24px;
     overflow: hidden;
     gap: 20px;
 }
 
 .gauge-chart {
-    height: 350px;
-    border-radius: 15px;
+    min-height: 350px;
+    border-radius: var(--radius);
     flex: 1;
+    min-width: 0;
     margin: 0;
     padding: 0;
     overflow: hidden;
-    background-color: #ffffff;
-    box-shadow: 0 10px 20px rgba(0,0,0,0.05);
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    background-color: var(--card-bg);
+    border: 1px solid var(--border);
+    box-shadow: var(--shadow-sm);
+    transition: transform var(--transition), box-shadow var(--transition);
 }
 
 .gauge-chart:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 15px 30px rgba(0,0,0,0.08);
+    box-shadow: var(--shadow-md);
 }
 
 /* Providers section */
 .providers-container {
     display: flex;
     justify-content: space-around;
-    margin-bottom: 20px;
+    gap: 24px;
     text-align: center;
+    flex-wrap: wrap;
+}
+
+.providers-container > div {
+    flex: 1;
+    min-width: 260px;
+}
+
+.providers-container h4 {
+    color: var(--heading);
 }
 
 .providers-container ul {
@@ -254,7 +459,10 @@ h1::after {
 /* SOC stats */
 .soc-stats {
     text-align: center;
-    margin-bottom: 20px;
+}
+
+.soc-stats h4 {
+    color: var(--heading);
 }
 
 .soc-stats ul {
@@ -268,39 +476,39 @@ h1::after {
 /* Charts */
 .chart {
     height: 400px;
-    border-radius: 15px;
-    margin-bottom: 35px;
+    border-radius: var(--radius);
+    margin-bottom: 26px;
     overflow: hidden;
-    background-color: #ffffff;
-    box-shadow: 0 10px 20px rgba(0,0,0,0.05);
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    background-color: var(--card-bg);
+    border: 1px solid var(--border);
+    box-shadow: var(--shadow-sm);
+    transition: transform var(--transition), box-shadow var(--transition);
 }
 
 .chart:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 15px 30px rgba(0,0,0,0.08);
+    box-shadow: var(--shadow-md);
 }
 
 /* Maps */
 .map {
     height: 450px;
-    border-radius: 15px;
-    margin-bottom: 30px;
+    border-radius: var(--radius);
+    margin-bottom: 26px;
     position: relative;
     z-index: 1;
     overflow: hidden;
-    box-shadow: 0 10px 20px rgba(0,0,0,0.05);
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    border: 1px solid var(--border);
+    box-shadow: var(--shadow-sm);
+    transition: transform var(--transition), box-shadow var(--transition);
 }
 
 .map:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 15px 30px rgba(0,0,0,0.08);
+    box-shadow: var(--shadow-md);
 }
 
 /* Specific styling for map section to ensure proper positioning */
 .map-section {
-    margin: 20px 0 30px 0;
+    margin: 20px 0 26px 0;
     width: 100%;
     display: block;
     clear: both;
@@ -316,7 +524,7 @@ h1::after {
     display: block;
 }
 
-/* Map legend styles */
+/* Map legend styles (maps keep light tiles, so keep light legend) */
 .info.legend {
     line-height: 18px;
     color: #333;
@@ -348,26 +556,33 @@ h1::after {
 
 /* Session selector */
 .session-selector {
-    width: 50%;
-    margin: 0 auto 20px;
+    width: 60%;
+    margin: 0 auto 26px;
     text-align: center;
+}
+
+.session-selector label {
+    color: var(--text);
+    font-weight: 500;
+    display: block;
+    margin-bottom: 8px;
 }
 
 .session-selector select {
     width: 100%;
-    padding: 8px;
-    border: 2px solid #3498db;
-    border-radius: 5px;
-    background-color: #fff;
-    color: #333;
+    padding: 10px;
+    border: 2px solid var(--border-strong);
+    border-radius: 8px;
+    background-color: var(--surface-2);
+    color: var(--text);
     font-size: 16px;
     cursor: pointer;
-    transition: border-color 0.3s ease, box-shadow 0.3s ease;
+    transition: border-color var(--transition), box-shadow var(--transition);
 }
 
 .session-selector select:hover,
 .session-selector select:focus {
-    border-color: #1abc9c;
+    border-color: var(--accent-2);
     box-shadow: 0 0 0 3px rgba(26, 188, 156, 0.2);
     outline: none;
 }
@@ -381,6 +596,7 @@ h1::after {
 .session-details h3 {
     text-align: center;
     margin-bottom: 20px;
+    color: var(--heading);
 }
 
 /* No data message styling */
@@ -390,10 +606,10 @@ h1::after {
     align-items: center;
     height: 100%;
     font-size: 18px;
-    color: #888;
+    color: var(--muted);
     text-align: center;
     padding: 20px;
-    background-color: rgba(0,0,0,0.02);
+    background-color: var(--surface-2);
     border-radius: 8px;
     font-style: italic;
 }
@@ -413,30 +629,29 @@ h1::after {
 /* Modern Session Cards */
 #combined-gauges {
     min-height: 400px;
-    border-radius: 15px;
-    margin-bottom: 30px;
+    border-radius: var(--radius);
+    margin-bottom: 26px;
     overflow: hidden;
-    background-color: #f8f9fa;
-    box-shadow: 0 10px 20px rgba(0,0,0,0.05);
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    background-color: var(--surface-2);
+    border: 1px solid var(--border);
+    box-shadow: var(--shadow-sm);
+    transition: transform var(--transition), box-shadow var(--transition);
     padding: 5px;
 }
 
 #combined-gauges:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 15px 30px rgba(0,0,0,0.08);
+    box-shadow: var(--shadow-md);
 }
 
 .session-metric-card, .session-info-card {
-    border-radius: 12px;
-    background-color: white;
-    box-shadow: 0 4px 12px rgba(0,0,0,0.08);
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    border-radius: var(--radius);
+    background-color: var(--card-bg);
+    box-shadow: var(--shadow-sm);
+    transition: transform var(--transition), box-shadow var(--transition);
 }
 
 .session-metric-card:hover, .session-info-card:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 8px 20px rgba(0,0,0,0.12);
+    box-shadow: var(--shadow-md);
 }
 
 /* Footer */
@@ -446,7 +661,7 @@ footer {
     padding: 20px 0;
     clear: both;
     position: relative;
-    border-top: 1px solid #ddd;
+    border-top: 1px solid var(--border);
     width: 100%;
 }
 
@@ -454,25 +669,26 @@ footer {
     margin: 20px auto;
     max-width: 600px;
     padding: 20px;
-    background-color: #ffffff;
-    border-radius: 12px;
-    box-shadow: 0 4px 12px rgba(0,0,0,0.08);
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    background-color: var(--card-bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow-sm);
+    transition: transform var(--transition), box-shadow var(--transition);
 }
 
 .imprint:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 8px 20px rgba(0,0,0,0.12);
+    box-shadow: var(--shadow-md);
 }
 
 .imprint h3 {
     margin-bottom: 15px;
     font-weight: 600;
+    color: var(--heading);
 }
 
 .imprint p {
     margin: 5px 0;
-    color: #666;
+    color: var(--muted);
 }
 
 /* Responsive styles */
@@ -480,20 +696,24 @@ footer {
     .upload-container {
         width: 90%;
     }
-    
+
     .session-selector {
         width: 90%;
     }
-    
+
     .gauge-row {
         flex-direction: column;
     }
-    
+
     .gauge-chart {
         margin-bottom: 10px;
     }
-    
+
     .session-details-container {
         flex-direction: column;
+    }
+
+    .theme-toggle {
+        top: 8px;
     }
 }

--- a/go-rewrite/static/index.html
+++ b/go-rewrite/static/index.html
@@ -4,6 +4,19 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>BMW CarData - Charging Session Dashboard</title>
+    <!-- Set theme before any paint to avoid flash of incorrect theme -->
+    <script>
+        (function() {
+            try {
+                var saved = localStorage.getItem('bmw-theme');
+                var theme = saved || (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+                document.documentElement.setAttribute('data-theme', theme);
+            } catch (e) {
+                document.documentElement.setAttribute('data-theme', 'light');
+            }
+        })();
+    </script>
+    <script src="/static/js/theme.js"></script>
     <!-- CSS will be loaded dynamically with cache busting -->
     <!-- Include Plotly.js -->
     <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
@@ -50,6 +63,10 @@
 <body>
     <div class="container">
         <header>
+            <button id="theme-toggle" class="theme-toggle" type="button" aria-label="Toggle dark mode" title="Toggle dark mode">
+                <span class="icon-moon" aria-hidden="true">🌙</span>
+                <span class="icon-sun" aria-hidden="true">☀️</span>
+            </button>
             <h1>BMW CarData - Charging Session Dashboard</h1>
             <nav class="main-nav">
                 <ul>

--- a/go-rewrite/static/js/app.js
+++ b/go-rewrite/static/js/app.js
@@ -7,54 +7,98 @@ let currentSession = null;
 let useMiles = false;
 let chargingLocationsMap = null;
 
-// Define a modern Plotly template with enhanced styling
-const plotlyTemplate = {
-    layout: {
-        paper_bgcolor: '#ffffff',
-        plot_bgcolor: '#ffffff',
-        font: {
-            family: 'SF Pro Display, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
-            color: '#444',
-            size: 12
-        },
-        title: {
+// Minimal line-icon set (stroke = currentColor) used in metric/summary cards
+// in place of emoji, for a cleaner, more professional appearance.
+const ICON_PATHS = {
+    bolt: '<path d="M13 2 4.5 13.5H11l-1 8.5L19.5 10H13z"/>',
+    chart: '<path d="M4 20V12M9.3 20V6M14.7 20v-8M20 20V9"/>',
+    battery: '<rect x="3" y="8" width="15" height="8" rx="2"/><path d="M21 11.5v3"/><path d="M6.5 10.5v3M9.5 10.5v3"/>',
+    plug: '<path d="M9 2v6M15 2v6M7 8h10v2a5 5 0 0 1-10 0zM12 15v6"/>',
+    euro: '<path d="M16.5 6.5a6 6 0 1 0 0 11M4.5 10h8M4.5 14h8"/>',
+    clock: '<circle cx="12" cy="12" r="9"/><path d="M12 7.5V12l3 2"/>',
+    calendar: '<rect x="3" y="5" width="18" height="16" rx="2"/><path d="M3 9.5h18M8 3v4M16 3v4"/>',
+    gauge: '<path d="M3.5 15a8.5 8.5 0 0 1 17 0"/><path d="M12 15l4.5-3.5"/><circle cx="12" cy="15" r="1.4"/>',
+    check: '<path d="M4.5 12.5 9.5 17.5 20 6.5"/>',
+    alert: '<path d="M12 3 22 20H2z"/><path d="M12 10v4.5M12 17.5h.01"/>',
+    cross: '<circle cx="12" cy="12" r="9"/><path d="M9 9l6 6M15 9l-6 6"/>',
+    scale: '<path d="M12 4v16M5 8h14M5 8 2.6 14a3 3 0 0 0 4.8 0zM19 8l-2.4 6a3 3 0 0 0 4.8 0z"/>'
+};
+
+function svgIcon(name, size) {
+    const path = ICON_PATHS[name] || ICON_PATHS.chart;
+    const s = size || 20;
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="${s}" height="${s}" viewBox="0 0 24 24" ` +
+        `fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">${path}</svg>`;
+}
+
+// Define a modern Plotly template with enhanced styling.
+// Colors are derived from the active CSS theme (see theme.js) so charts
+// match light/dark mode. Rebuilt on theme change via rebuildPlotlyTemplate().
+const PLOTLY_FONT_FAMILY = 'SF Pro Display, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif';
+
+function buildPlotlyTemplate() {
+    const t = (window.BMWTheme && window.BMWTheme.plotlyLayout) ? window.BMWTheme.plotlyLayout() : {};
+    const surface = t.paper_bgcolor || '#ffffff';
+    const text = (t.title && t.title.font && t.title.font.color) || '#333';
+    const muted = (t.font && t.font.color) || '#555';
+    const grid = (t.xaxis && t.xaxis.gridcolor) || '#f0f0f0';
+    const border = (t.xaxis && t.xaxis.zerolinecolor) || '#e0e0e0';
+    return {
+        layout: {
+            paper_bgcolor: surface,
+            plot_bgcolor: surface,
             font: {
-                family: 'SF Pro Display, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
-                size: 18,
-                color: '#333'
-            }
-        },
-        colorway: ['#3498db', '#2ecc71', '#f39c12', '#e74c3c', '#9b59b6', '#1abc9c', '#34495e', '#7f8c8d', '#d35400', '#c0392b'],
-        legend: {
-            bgcolor: '#ffffff',
-            bordercolor: '#f0f0f0',
-            borderwidth: 1,
-            font: {
-                family: 'SF Pro Display, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
-                size: 12,
-                color: '#555'
-            }
-        },
-        xaxis: {
-            gridcolor: '#f0f0f0',
-            zerolinecolor: '#e0e0e0',
-            tickfont: {
-                family: 'SF Pro Display, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
-                size: 12,
-                color: '#555'
-            }
-        },
-        yaxis: {
-            gridcolor: '#f0f0f0',
-            zerolinecolor: '#e0e0e0',
-            tickfont: {
-                family: 'SF Pro Display, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
-                size: 12,
-                color: '#555'
+                family: PLOTLY_FONT_FAMILY,
+                color: muted,
+                size: 12
+            },
+            title: {
+                font: {
+                    family: PLOTLY_FONT_FAMILY,
+                    size: 18,
+                    color: text
+                }
+            },
+            colorway: ['#3498db', '#2ecc71', '#f39c12', '#e74c3c', '#9b59b6', '#1abc9c', '#34495e', '#7f8c8d', '#d35400', '#c0392b'],
+            legend: {
+                bgcolor: surface,
+                bordercolor: border,
+                borderwidth: 1,
+                font: {
+                    family: PLOTLY_FONT_FAMILY,
+                    size: 12,
+                    color: muted
+                }
+            },
+            xaxis: {
+                gridcolor: grid,
+                zerolinecolor: border,
+                tickfont: {
+                    family: PLOTLY_FONT_FAMILY,
+                    size: 12,
+                    color: muted
+                }
+            },
+            yaxis: {
+                gridcolor: grid,
+                zerolinecolor: border,
+                tickfont: {
+                    family: PLOTLY_FONT_FAMILY,
+                    size: 12,
+                    color: muted
+                }
             }
         }
-    }
-};
+    };
+}
+
+let plotlyTemplate = buildPlotlyTemplate();
+
+// Resolve a CSS theme token to its current value, for use inside Plotly
+// layout/trace objects (Plotly cannot read CSS variables directly).
+function themeColor(name, fallback) {
+    return (window.BMWTheme && window.BMWTheme.cssVar) ? window.BMWTheme.cssVar(name, fallback) : fallback;
+}
 
 // DOM elements
 const disclaimerEl = document.getElementById('disclaimer');
@@ -87,6 +131,17 @@ function setupEventListeners() {
     applyDateFilterBtn.addEventListener('click', applyDateFilter);
     toggleUnitsBtn.addEventListener('click', toggleUnits);
     sessionDropdownEl.addEventListener('change', handleSessionSelection);
+
+    // Re-render Plotly charts when the color theme changes
+    window.addEventListener('bmwthemechange', () => {
+        plotlyTemplate = buildPlotlyTemplate();
+        if (window.__lastStats) {
+            updateDashboardVisualizations(window.__lastStats);
+        }
+        if (currentSession) {
+            updateSessionDetails();
+        }
+    });
     
     // Set up consent checkbox to show/hide model selector
     const consentCheckbox = document.getElementById('fleet-stats-consent');
@@ -302,6 +357,9 @@ async function loadSessionData() {
         
         const stats = await statsResponse.json();
 
+        // Cache the latest stats so charts can be re-rendered on theme change
+        window.__lastStats = stats;
+
         // Update UI with fetched data
         updateSessionDropdown();
         updateDashboardVisualizations(stats);
@@ -345,6 +403,11 @@ function updateSessionDropdown() {
 
 // Update dashboard visualizations
 function updateDashboardVisualizations(stats) {
+    // Rebuild the Plotly theme template now that the (async) stylesheet is
+    // applied, so the very first render already matches the active light/dark
+    // theme instead of the light fallback captured at module load.
+    plotlyTemplate = buildPlotlyTemplate();
+
     // Create gauges
     createTotalEnergyGauge();
     updateCurrentKmGauge();
@@ -441,11 +504,16 @@ function createTotalEnergyGauge() {
     const layout = {
         title: {
             text: 'Total Energy Consumption',
-            font: { size: 20, color: '#444', family: 'Roboto, sans-serif' }
+            font: { size: 17, color: themeColor('--heading', '#2c3e50'), family: 'Roboto, sans-serif' },
+            x: 0,
+            xanchor: 'left',
+            xref: 'paper',
+            y: 0.97,
+            yanchor: 'top'
         },
         barmode: 'stack',
-        height: 280,
-        margin: { t: 60, b: 40, l: 70, r: 40 },
+        height: 300,
+        margin: { t: 50, b: 70, l: 70, r: 40 },
         template: plotlyTemplate,
         yaxis: {
             title: {
@@ -458,8 +526,8 @@ function createTotalEnergyGauge() {
         },
         legend: {
             orientation: 'h',
-            yanchor: 'bottom',
-            y: 1.02,
+            yanchor: 'top',
+            y: -0.12,
             xanchor: 'center',
             x: 0.5
         },
@@ -472,16 +540,16 @@ function createTotalEnergyGauge() {
                 arrowhead: 0,
                 arrowsize: 1,
                 arrowwidth: 1,
-                arrowcolor: '#666',
+                arrowcolor: themeColor('--muted', '#666'),
                 ax: 0,
                 ay: -40,
                 font: {
                     size: 14,
-                    color: '#444',
+                    color: themeColor('--text', '#2c3e50'),
                     weight: 'bold'
                 },
-                bgcolor: 'rgba(255, 255, 255, 0.8)',
-                bordercolor: '#ddd',
+                bgcolor: themeColor('--card-bg', '#ffffff'),
+                bordercolor: themeColor('--border', '#ddd'),
                 borderwidth: 1,
                 borderpad: 4,
                 opacity: 0.9
@@ -490,7 +558,7 @@ function createTotalEnergyGauge() {
     };
     
     // Create the stacked bar chart
-    Plotly.newPlot('total-energy-gauge', data, layout, {responsive: true});
+    Plotly.newPlot('total-energy-gauge', data, layout, {responsive: true, displayModeBar: false});
     
     // Add additional information card below the chart
     const gaugeContainer = document.getElementById('total-energy-gauge');
@@ -508,7 +576,7 @@ function createTotalEnergyGauge() {
     infoCard.style.justifyContent = 'space-around';
     infoCard.style.marginTop = '10px';
     infoCard.style.padding = '10px';
-    infoCard.style.backgroundColor = '#f8f9fa';
+    infoCard.style.backgroundColor = 'var(--surface-2)';
     infoCard.style.borderRadius = '8px';
     infoCard.style.boxShadow = '0 2px 4px rgba(0,0,0,0.05)';
     
@@ -519,20 +587,22 @@ function createTotalEnergyGauge() {
         stat.style.padding = '10px';
         
         const iconEl = document.createElement('div');
-        iconEl.textContent = icon;
-        iconEl.style.fontSize = '24px';
-        iconEl.style.marginBottom = '5px';
+        iconEl.innerHTML = svgIcon(icon, 20);
+        iconEl.style.color = 'var(--accent)';
+        iconEl.style.marginBottom = '6px';
+        iconEl.style.display = 'flex';
+        iconEl.style.justifyContent = 'center';
         
         const valueEl = document.createElement('div');
         valueEl.textContent = value;
         valueEl.style.fontSize = '18px';
-        valueEl.style.fontWeight = 'bold';
-        valueEl.style.color = color;
+        valueEl.style.fontWeight = '600';
+        valueEl.style.color = 'var(--heading)';
         
         const labelEl = document.createElement('div');
         labelEl.textContent = label;
         labelEl.style.fontSize = '12px';
-        labelEl.style.color = '#777';
+        labelEl.style.color = 'var(--muted)';
         
         stat.appendChild(iconEl);
         stat.appendChild(valueEl);
@@ -552,10 +622,10 @@ function createTotalEnergyGauge() {
         ((totalEnergyAc / totalEnergy) * 100).toFixed(0) + '%' : '0%';
     
     // Add the stats to the card
-    infoCard.appendChild(createEnergyStat('Total Energy', totalEnergy.toFixed(1) + ' kWh', '#9c27b0', '⚡'));
-    infoCard.appendChild(createEnergyStat('Avg per Session', avgEnergyPerSession, '#2196f3', '📊'));
-    infoCard.appendChild(createEnergyStat('DC Charging', dcPercentage, '#3498db', '🔋'));
-    infoCard.appendChild(createEnergyStat('AC Charging', acPercentage, '#2ecc71', '🔌'));
+    infoCard.appendChild(createEnergyStat('Total Energy', totalEnergy.toFixed(1) + ' kWh', '#9c27b0', 'bolt'));
+    infoCard.appendChild(createEnergyStat('Avg per Session', avgEnergyPerSession, '#2196f3', 'chart'));
+    infoCard.appendChild(createEnergyStat('DC Charging', dcPercentage, '#3498db', 'battery'));
+    infoCard.appendChild(createEnergyStat('AC Charging', acPercentage, '#2ecc71', 'plug'));
     
     // Add the info card to the container
     gaugeContainer.appendChild(infoCard);
@@ -623,21 +693,17 @@ function updateCurrentKmGauge() {
     card.style.justifyContent = 'center';
     card.style.alignItems = 'center';
     card.style.padding = '20px';
-    card.style.backgroundColor = '#ffffff';
-    card.style.borderRadius = '10px';
-    card.style.boxShadow = '0 4px 12px rgba(0,0,0,0.08)';
+    card.style.backgroundColor = 'var(--card-bg)';
+    card.style.borderRadius = 'var(--radius)';
+    card.style.border = '1px solid var(--border)';
+    card.style.boxShadow = 'var(--shadow-sm)';
     card.style.position = 'relative';
     card.style.overflow = 'hidden';
-    card.style.transition = 'transform 0.3s ease';
-    
-    // Add hover effect
-    card.onmouseover = () => card.style.transform = 'translateY(-5px)';
-    card.onmouseout = () => card.style.transform = 'translateY(0)';
     
     // Create the header section
     const header = document.createElement('div');
     header.style.width = '100%';
-    header.style.borderBottom = '1px solid #f0f0f0';
+    header.style.borderBottom = '1px solid var(--border)';
     header.style.paddingBottom = '15px';
     header.style.marginBottom = '15px';
     header.style.textAlign = 'center';
@@ -645,7 +711,7 @@ function updateCurrentKmGauge() {
     const title = document.createElement('h3');
     title.textContent = 'Distance Covered';
     title.style.margin = '0';
-    title.style.color = '#444';
+    title.style.color = 'var(--text)';
     title.style.fontSize = '18px';
     header.appendChild(title);
     
@@ -657,18 +723,16 @@ function updateCurrentKmGauge() {
     distanceContainer.style.margin = '20px 0';
     
     const distanceValue = document.createElement('div');
-    distanceValue.style.fontSize = '56px';
+    distanceValue.style.fontSize = '52px';
     distanceValue.style.fontWeight = '700';
-    distanceValue.style.color = '#1f77b4';
+    distanceValue.style.color = 'var(--heading)';
     distanceValue.style.lineHeight = '1';
-    distanceValue.style.background = 'linear-gradient(45deg, #1f77b4, #2ca8ff)';
-    distanceValue.style.WebkitBackgroundClip = 'text';
-    distanceValue.style.WebkitTextFillColor = 'transparent';
+    distanceValue.style.letterSpacing = '-0.02em';
     distanceValue.textContent = Math.round(displayDistance).toLocaleString();
     
     const distanceUnit = document.createElement('div');
     distanceUnit.style.fontSize = '18px';
-    distanceUnit.style.color = '#777';
+    distanceUnit.style.color = 'var(--muted)';
     distanceUnit.style.marginTop = '5px';
     distanceUnit.textContent = unitLabel;
     
@@ -689,25 +753,27 @@ function updateCurrentKmGauge() {
         stat.style.display = 'flex';
         stat.style.flexDirection = 'column';
         stat.style.alignItems = 'center';
-        stat.style.backgroundColor = '#f8f9fa';
+        stat.style.backgroundColor = 'var(--surface-2)';
         stat.style.padding = '12px';
         stat.style.borderRadius = '8px';
         
         const iconElement = document.createElement('div');
-        iconElement.textContent = icon;
-        iconElement.style.fontSize = '20px';
-        iconElement.style.marginBottom = '5px';
+        iconElement.innerHTML = svgIcon(icon, 18);
+        iconElement.style.color = 'var(--accent)';
+        iconElement.style.marginBottom = '6px';
+        iconElement.style.display = 'flex';
+        iconElement.style.justifyContent = 'center';
         
         const valueElement = document.createElement('div');
         valueElement.textContent = value;
         valueElement.style.fontSize = '18px';
         valueElement.style.fontWeight = '600';
-        valueElement.style.color = '#444';
+        valueElement.style.color = 'var(--text)';
         
         const labelElement = document.createElement('div');
         labelElement.textContent = label;
         labelElement.style.fontSize = '12px';
-        labelElement.style.color = '#777';
+        labelElement.style.color = 'var(--muted)';
         
         stat.appendChild(iconElement);
         stat.appendChild(valueElement);
@@ -717,14 +783,14 @@ function updateCurrentKmGauge() {
     }
     
     // Add stat items
-    statsContainer.appendChild(createStatItem('Time Period', dayDiff + ' days', '📅'));
-    statsContainer.appendChild(createStatItem('Sessions', numSessions, '🔌'));
+    statsContainer.appendChild(createStatItem('Time Period', dayDiff + ' days', 'calendar'));
+    statsContainer.appendChild(createStatItem('Sessions', numSessions, 'plug'));
     
     // Add date range info
     const dateRange = document.createElement('div');
     dateRange.style.marginTop = '20px';
     dateRange.style.fontSize = '13px';
-    dateRange.style.color = '#666';
+    dateRange.style.color = 'var(--muted)';
     dateRange.style.textAlign = 'center';
     dateRange.style.width = '100%';
     dateRange.textContent = `${firstDate.toLocaleDateString()} - ${lastDate.toLocaleDateString()}`;
@@ -773,22 +839,18 @@ function createOverallEfficiencyGauge(efficiency) {
     card.style.flexDirection = 'column';
     card.style.justifyContent = 'center';
     card.style.alignItems = 'center';
-    card.style.backgroundColor = '#ffffff';
-    card.style.borderRadius = '10px';
-    card.style.boxShadow = '0 4px 12px rgba(0,0,0,0.08)';
+    card.style.backgroundColor = 'var(--card-bg)';
+    card.style.borderRadius = 'var(--radius)';
+    card.style.border = '1px solid var(--border)';
+    card.style.boxShadow = 'var(--shadow-sm)';
     card.style.position = 'relative';
     card.style.padding = '20px';
-    card.style.transition = 'transform 0.3s ease';
-    
-    // Add hover effect
-    card.onmouseover = () => card.style.transform = 'translateY(-5px)';
-    card.onmouseout = () => card.style.transform = 'translateY(0)';
     
     // Create title
     const title = document.createElement('h3');
     title.textContent = 'Overall Charging Efficiency';
     title.style.margin = '0 0 20px 0';
-    title.style.color = '#444';
+    title.style.color = 'var(--text)';
     title.style.fontSize = '18px';
     title.style.textAlign = 'center';
     
@@ -823,7 +885,7 @@ function createOverallEfficiencyGauge(efficiency) {
     backgroundCircle.setAttribute('cy', '50');
     backgroundCircle.setAttribute('r', '45');
     backgroundCircle.setAttribute('fill', 'none');
-    backgroundCircle.setAttribute('stroke', '#f0f0f0');
+    backgroundCircle.setAttribute('stroke', themeColor('--track', '#f0f0f0'));
     backgroundCircle.setAttribute('stroke-width', '10');
     
     // Add gradient definition
@@ -887,7 +949,7 @@ function createOverallEfficiencyGauge(efficiency) {
     const label = document.createElement('div');
     label.textContent = 'Efficiency';
     label.style.fontSize = '14px';
-    label.style.color = '#777';
+    label.style.color = 'var(--muted)';
     
     valueContainer.appendChild(value);
     valueContainer.appendChild(label);
@@ -921,7 +983,7 @@ function createOverallEfficiencyGauge(efficiency) {
     const explanation = document.createElement('div');
     explanation.textContent = 'Energy transferred from grid to battery';
     explanation.style.fontSize = '13px';
-    explanation.style.color = '#777';
+    explanation.style.color = 'var(--muted)';
     
     ratingContainer.appendChild(rating);
     ratingContainer.appendChild(explanation);
@@ -979,7 +1041,7 @@ function createPowerConsumptionGauge(consumption, consumptionWithoutLosses) {
             hovertemplate: '%{y:.1f} kWh/100km<extra></extra>', // Custom hover template
             textfont: {
                 size: 14,
-                color: '#333'
+                color: themeColor('--text', '#2c3e50')
             }
         }
     ];
@@ -987,10 +1049,15 @@ function createPowerConsumptionGauge(consumption, consumptionWithoutLosses) {
     const layout = {
         title: {
             text: 'Power Consumption Comparison',
-            font: { size: 20, color: '#444', family: 'Roboto, sans-serif' }
+            font: { size: 17, color: themeColor('--text', '#2c3e50'), family: 'Roboto, sans-serif' },
+            x: 0,
+            xanchor: 'left',
+            xref: 'paper',
+            y: 0.97,
+            yanchor: 'top'
         },
         height: 300,
-        margin: { t: 60, b: 80, l: 70, r: 40 },
+        margin: { t: 50, b: 80, l: 70, r: 40 },
         template: plotlyTemplate,
         yaxis: {
             title: {
@@ -1010,7 +1077,7 @@ function createPowerConsumptionGauge(consumption, consumptionWithoutLosses) {
                 text: consumption.toFixed(1) + ' kWh/100km', // Include units in the annotation
                 showarrow: false,
                 yshift: 15, // Move above the bar instead of inside it
-                font: { size: 14, color: '#333', weight: 'bold' }
+                font: { size: 14, color: themeColor('--text', '#2c3e50'), weight: 'bold' }
             },
             {
                 x: 1,
@@ -1018,7 +1085,7 @@ function createPowerConsumptionGauge(consumption, consumptionWithoutLosses) {
                 text: consumptionWithoutLosses.toFixed(1) + ' kWh/100km', // Include units in the annotation
                 showarrow: false,
                 yshift: 15, // Move above the bar instead of inside it
-                font: { size: 14, color: '#333', weight: 'bold' }
+                font: { size: 14, color: themeColor('--text', '#2c3e50'), weight: 'bold' }
             }
         ]
     };
@@ -1027,7 +1094,7 @@ function createPowerConsumptionGauge(consumption, consumptionWithoutLosses) {
     const savingsPercentage = ((consumption - consumptionWithoutLosses) / consumption * 100).toFixed(1);
     
     // Combine both gauges into a single visualization
-    Plotly.newPlot('power-consumption-gauge', data, layout);
+    Plotly.newPlot('power-consumption-gauge', data, layout, {responsive: true, displayModeBar: false});
     
     // Add custom HTML to the second gauge container to display savings
     const efficiencyContainer = document.getElementById('power-consumption-without-grid-losses-gauge');
@@ -1040,21 +1107,17 @@ function createPowerConsumptionGauge(consumption, consumptionWithoutLosses) {
     savingsCard.style.flexDirection = 'column';
     savingsCard.style.justifyContent = 'center';
     savingsCard.style.alignItems = 'center';
-    savingsCard.style.backgroundColor = '#ffffff';
-    savingsCard.style.borderRadius = '10px';
-    savingsCard.style.boxShadow = '0 4px 12px rgba(0,0,0,0.08)';
+    savingsCard.style.backgroundColor = 'var(--card-bg)';
+    savingsCard.style.borderRadius = 'var(--radius)';
+    savingsCard.style.border = '1px solid var(--border)';
+    savingsCard.style.boxShadow = 'var(--shadow-sm)';
     savingsCard.style.padding = '20px';
-    savingsCard.style.transition = 'transform 0.3s ease';
-    
-    // Add hover effect
-    savingsCard.onmouseover = () => savingsCard.style.transform = 'translateY(-5px)';
-    savingsCard.onmouseout = () => savingsCard.style.transform = 'translateY(0)';
     
     // Create header
     const header = document.createElement('h3');
     header.textContent = 'Charging Energy Overhead';
     header.style.margin = '0 0 20px 0';
-    header.style.color = '#444';
+    header.style.color = 'var(--text)';
     header.style.fontSize = '18px';
     header.style.textAlign = 'center';
     
@@ -1064,18 +1127,17 @@ function createPowerConsumptionGauge(consumption, consumptionWithoutLosses) {
     savingsValueContainer.style.marginBottom = '10px';
     
     const savingsValue = document.createElement('div');
-    savingsValue.style.fontSize = '64px';
-    savingsValue.style.fontWeight = 'bold';
-    savingsValue.style.background = 'linear-gradient(45deg, #4A90E2, #6BD098)';
-    savingsValue.style.WebkitBackgroundClip = 'text';
-    savingsValue.style.WebkitTextFillColor = 'transparent';
+    savingsValue.style.fontSize = '60px';
+    savingsValue.style.fontWeight = '700';
+    savingsValue.style.color = 'var(--heading)';
+    savingsValue.style.letterSpacing = '-0.02em';
     savingsValue.style.lineHeight = '1';
     savingsValue.textContent = savingsPercentage + '%';
     
     const savingsLabel = document.createElement('div');
     savingsLabel.textContent = 'Energy overhead from grid losses';
     savingsLabel.style.fontSize = '14px';
-    savingsLabel.style.color = '#777';
+    savingsLabel.style.color = 'var(--muted)';
     savingsLabel.style.marginTop = '10px';
     
     savingsValueContainer.appendChild(savingsValue);
@@ -1101,12 +1163,12 @@ function createPowerConsumptionGauge(consumption, consumptionWithoutLosses) {
     
     rows.forEach(row => {
         const tr = document.createElement('tr');
-        tr.style.borderBottom = '1px solid #f0f0f0';
+        tr.style.borderBottom = '1px solid var(--border)';
         
         const tdLabel = document.createElement('td');
         tdLabel.textContent = row.label;
         tdLabel.style.padding = '10px 0';
-        tdLabel.style.color = '#555';
+        tdLabel.style.color = 'var(--muted)';
         
         const tdValue = document.createElement('td');
         tdValue.textContent = row.value;
@@ -1126,7 +1188,7 @@ function createPowerConsumptionGauge(consumption, consumptionWithoutLosses) {
     const note = document.createElement('div');
     note.textContent = 'Note: Grid losses include AC/DC conversion inefficiency, heat generation, and energy used for preconditioning while charging';
     note.style.fontSize = '12px';
-    note.style.color = '#999';
+    note.style.color = 'var(--muted)';
     note.style.marginTop = '20px';
     note.style.textAlign = 'center';
     
@@ -1154,15 +1216,16 @@ function renderFailureReasons(reasons, affectedSessions, totalFailed) {
     box.className = 'failure-reasons-breakdown';
     box.style.marginBottom = '30px';
     box.style.padding = '20px 24px';
-    box.style.backgroundColor = '#ffffff';
-    box.style.borderRadius = '15px';
-    box.style.boxShadow = '0 10px 20px rgba(0,0,0,0.05)';
+    box.style.backgroundColor = 'var(--card-bg)';
+    box.style.borderRadius = 'var(--radius)';
+    box.style.border = '1px solid var(--border)';
+    box.style.boxShadow = 'var(--shadow-sm)';
 
     const title = document.createElement('div');
     title.textContent = 'Most common charging errors';
     title.style.fontSize = '18px';
     title.style.fontWeight = '600';
-    title.style.color = '#444';
+    title.style.color = 'var(--text)';
     title.style.marginBottom = '4px';
     box.appendChild(title);
 
@@ -1174,7 +1237,7 @@ function renderFailureReasons(reasons, affectedSessions, totalFailed) {
             ? `${affectedSessions} of ${totalFailed} failed sessions reported a reason — the other ${noReason} aborted without one`
             : `All ${totalFailed} failed sessions reported a reason`;
         subtitle.style.fontSize = '13px';
-        subtitle.style.color = '#888';
+        subtitle.style.color = 'var(--muted)';
         subtitle.style.marginBottom = '14px';
         box.appendChild(subtitle);
     }
@@ -1193,7 +1256,7 @@ function renderFailureReasons(reasons, affectedSessions, totalFailed) {
         head.style.display = 'flex';
         head.style.justifyContent = 'space-between';
         head.style.fontSize = '14px';
-        head.style.color = '#555';
+        head.style.color = 'var(--muted)';
         head.style.marginBottom = '4px';
         const label = document.createElement('span');
         label.textContent = labelText;
@@ -1206,7 +1269,7 @@ function renderFailureReasons(reasons, affectedSessions, totalFailed) {
 
         const track = document.createElement('div');
         track.style.height = '8px';
-        track.style.backgroundColor = '#f0f0f0';
+        track.style.backgroundColor = 'var(--track)';
         track.style.borderRadius = '4px';
         track.style.overflow = 'hidden';
         const bar = document.createElement('div');
@@ -1259,7 +1322,7 @@ function createSessionStatsGauges(sessionStats) {
     const layout = {
         title: {
             text: 'Charging Sessions Overview',
-            font: { size: 18, color: '#444' }
+            font: { size: 18, color: themeColor('--text', '#2c3e50') }
         },
         height: 300,
         showlegend: true,
@@ -1272,7 +1335,7 @@ function createSessionStatsGauges(sessionStats) {
         annotations: [{
             font: {
                 size: 20,
-                color: '#444'
+                color: themeColor('--text', '#2c3e50')
             },
             showarrow: false,
             text: totalSessions,
@@ -1282,7 +1345,7 @@ function createSessionStatsGauges(sessionStats) {
         {
             font: {
                 size: 14,
-                color: '#777'
+                color: themeColor('--muted', '#777')
             },
             showarrow: false,
             text: 'TOTAL',
@@ -1295,8 +1358,8 @@ function createSessionStatsGauges(sessionStats) {
     Plotly.newPlot('total-sessions-gauge', data, layout);
     
     // Create modern cards for failed and successful sessions
-    createSessionStatCard('failed-sessions-gauge', failedSessions, totalSessions, 'Failed Sessions', '#EF5350', '❌');
-    createSessionStatCard('successful-sessions-gauge', successfulSessions, totalSessions, 'Successful Sessions', '#66BB6A', '✅');
+    createSessionStatCard('failed-sessions-gauge', failedSessions, totalSessions, 'Failed Sessions', '#EF5350', 'cross');
+    createSessionStatCard('successful-sessions-gauge', successfulSessions, totalSessions, 'Successful Sessions', '#66BB6A', 'check');
 
     // Show the most common charging errors (from BMW businessErrors) when present.
     renderFailureReasons(sessionStats.error_breakdown || [], sessionStats.sessions_with_errors || 0, sessionStats.total_failed_sessions || 0);
@@ -1309,32 +1372,30 @@ function createSessionStatsGauges(sessionStats) {
         // Create the card
         const card = document.createElement('div');
         card.style.height = '100%';
-        card.style.backgroundColor = '#ffffff';
-        card.style.borderRadius = '10px';
-        card.style.boxShadow = '0 4px 12px rgba(0,0,0,0.08)';
+        card.style.backgroundColor = 'var(--card-bg)';
+        card.style.borderRadius = 'var(--radius)';
+        card.style.border = '1px solid var(--border)';
+        card.style.boxShadow = 'var(--shadow-sm)';
         card.style.padding = '20px';
         card.style.display = 'flex';
         card.style.flexDirection = 'column';
         card.style.alignItems = 'center';
         card.style.justifyContent = 'center';
-        card.style.transition = 'transform 0.3s ease';
-        
-        // Add hover effect
-        card.onmouseover = () => card.style.transform = 'translateY(-5px)';
-        card.onmouseout = () => card.style.transform = 'translateY(0)';
         
         // Create an icon for the card
         const iconElement = document.createElement('div');
-        iconElement.textContent = icon;
-        iconElement.style.fontSize = '36px';
-        iconElement.style.marginBottom = '10px';
+        iconElement.innerHTML = svgIcon(icon, 26);
+        iconElement.style.color = color;
+        iconElement.style.marginBottom = '12px';
+        iconElement.style.display = 'flex';
+        iconElement.style.justifyContent = 'center';
         
         // Create title
         const titleElement = document.createElement('h3');
         titleElement.textContent = title;
         titleElement.style.margin = '0 0 15px 0';
         titleElement.style.fontSize = '18px';
-        titleElement.style.color = '#444';
+        titleElement.style.color = 'var(--text)';
         titleElement.style.textAlign = 'center';
         
         // Create value container
@@ -1357,7 +1418,7 @@ function createSessionStatsGauges(sessionStats) {
         percentageElement.textContent = `${percentage}% of total`;
         percentageElement.style.marginTop = '5px';
         percentageElement.style.fontSize = '14px';
-        percentageElement.style.color = '#777';
+        percentageElement.style.color = 'var(--muted)';
         
         valueContainer.appendChild(valueElement);
         valueContainer.appendChild(percentageElement);
@@ -1371,7 +1432,7 @@ function createSessionStatsGauges(sessionStats) {
         const progressBackground = document.createElement('div');
         progressBackground.style.width = '100%';
         progressBackground.style.height = '6px';
-        progressBackground.style.backgroundColor = '#f0f0f0';
+        progressBackground.style.backgroundColor = 'var(--track)';
         progressBackground.style.borderRadius = '3px';
         progressBackground.style.overflow = 'hidden';
         
@@ -1396,7 +1457,7 @@ function createSessionStatsGauges(sessionStats) {
         const contextElement = document.createElement('div');
         contextElement.style.marginTop = '20px';
         contextElement.style.fontSize = '13px';
-        contextElement.style.color = '#777';
+        contextElement.style.color = 'var(--muted)';
         contextElement.style.textAlign = 'center';
         
         if (title.includes('Failed')) {
@@ -1427,7 +1488,7 @@ async function updateProviderLists(sessionStats) {
             titleEl.textContent = title;
             titleEl.style.margin = '10px 0';
             titleEl.style.fontSize = '16px';
-            titleEl.style.color = '#333';
+            titleEl.style.color = 'var(--heading)';
             titleEl.style.fontWeight = '600';
             element.appendChild(titleEl);
         }
@@ -1458,7 +1519,7 @@ async function updateProviderLists(sessionStats) {
         const failedTitle = document.createElement('h3');
         failedTitle.textContent = 'Top 5 Failed Providers';
         failedTitle.style.margin = '10px 0';
-        failedTitle.style.color = '#333';
+        failedTitle.style.color = 'var(--heading)';
         failedTitle.style.fontWeight = '600';
         failedTitle.style.fontSize = '18px';
         failedTitle.style.textAlign = 'center';
@@ -1467,7 +1528,7 @@ async function updateProviderLists(sessionStats) {
         const successTitle = document.createElement('h3');
         successTitle.textContent = 'Top 5 Successful Providers';
         successTitle.style.margin = '10px 0';
-        successTitle.style.color = '#333';
+        successTitle.style.color = 'var(--heading)';
         successTitle.style.fontWeight = '600';
         successTitle.style.fontSize = '18px';
         successTitle.style.textAlign = 'center';
@@ -1479,7 +1540,7 @@ async function updateProviderLists(sessionStats) {
         thresholdNote.textContent = 'Note: Only providers with 50+ sessions are displayed in these charts';
         thresholdNote.style.fontSize = '12px';
         thresholdNote.style.fontStyle = 'italic';
-        thresholdNote.style.color = '#666';
+        thresholdNote.style.color = 'var(--muted)';
         thresholdNote.style.textAlign = 'center';
         thresholdNote.style.margin = '0 0 10px 0';
         
@@ -1535,7 +1596,7 @@ async function updateProviderLists(sessionStats) {
             const li = document.createElement('div');
             li.style.padding = '10px';
             li.style.margin = '8px 0';
-            li.style.backgroundColor = '#f5f5f5';
+            li.style.backgroundColor = 'var(--surface-2)';
             li.style.borderRadius = '8px';
             li.style.boxShadow = '0 2px 4px rgba(0,0,0,0.1)';
             
@@ -1550,7 +1611,7 @@ async function updateProviderLists(sessionStats) {
             const providerName = document.createElement('span');
             providerName.textContent = name;
             providerName.style.fontWeight = 'bold';
-            providerName.style.color = '#333';
+            providerName.style.color = 'var(--text)';
             providerName.style.fontSize = '14px';
             providerName.style.flexGrow = '1';
             
@@ -1581,7 +1642,7 @@ async function updateProviderLists(sessionStats) {
             percentageInfo.style.justifyContent = 'space-between';
             percentageInfo.style.marginBottom = '2px';
             percentageInfo.style.fontSize = '11px';
-            percentageInfo.style.color = '#666';
+            percentageInfo.style.color = 'var(--muted)';
             
             const totalSessionsText = document.createElement('span');
             totalSessionsText.textContent = `${total} total sessions`;
@@ -1599,7 +1660,7 @@ async function updateProviderLists(sessionStats) {
             // Bar background
             const percentageBar = document.createElement('div');
             percentageBar.style.height = '6px';
-            percentageBar.style.backgroundColor = '#e0e0e0';
+            percentageBar.style.backgroundColor = 'var(--track)';
             percentageBar.style.borderRadius = '3px';
             percentageBar.style.overflow = 'hidden';
             percentageBar.style.position = 'relative';
@@ -1696,7 +1757,7 @@ async function updateProviderLists(sessionStats) {
             noFailures.textContent = 'No failed sessions data available';
             noFailures.style.padding = '10px';
             noFailures.style.textAlign = 'center';
-            noFailures.style.color = '#666';
+            noFailures.style.color = 'var(--muted)';
             topFailedProvidersEl.appendChild(noFailures);
         }
         
@@ -1712,7 +1773,7 @@ async function updateProviderLists(sessionStats) {
             noSuccess.textContent = 'No successful sessions data available';
             noSuccess.style.padding = '10px';
             noSuccess.style.textAlign = 'center';
-            noSuccess.style.color = '#666';
+            noSuccess.style.color = 'var(--muted)';
             topSuccessfulProvidersEl.appendChild(noSuccess);
         }
     }
@@ -1739,7 +1800,7 @@ async function updateProviderLists(sessionStats) {
         section.style.marginTop = '30px';
         section.style.marginBottom = '30px';
         section.style.padding = '15px';
-        section.style.backgroundColor = '#f9f9f9';
+        section.style.backgroundColor = 'var(--surface-2)';
         section.style.borderRadius = '8px';
         section.style.boxShadow = '0 2px 4px rgba(0,0,0,0.1)';
         
@@ -1846,7 +1907,7 @@ async function updateProviderLists(sessionStats) {
 function createSOCProgressBar(label, percentage, color) {
     const container = document.createElement('div');
     container.style.marginBottom = '8px';
-    container.style.backgroundColor = '#ffffff';
+    container.style.backgroundColor = 'var(--card-bg)';
     container.style.borderRadius = '6px';
     container.style.padding = '10px';
     container.style.boxShadow = '0 1px 3px rgba(0,0,0,0.1)';
@@ -1860,7 +1921,7 @@ function createSOCProgressBar(label, percentage, color) {
     const labelEl = document.createElement('span');
     labelEl.textContent = label;
     labelEl.style.fontWeight = 'bold';
-    labelEl.style.color = '#555555';
+    labelEl.style.color = 'var(--muted)';
     labelEl.style.fontSize = '13px';
     
     // Handle undefined or null percentages safely
@@ -1878,7 +1939,7 @@ function createSOCProgressBar(label, percentage, color) {
     // Create progress bar background
     const progressBarBg = document.createElement('div');
     progressBarBg.style.height = '10px';
-    progressBarBg.style.backgroundColor = '#f0f0f0';
+    progressBarBg.style.backgroundColor = 'var(--track)';
     progressBarBg.style.borderRadius = '5px';
     progressBarBg.style.overflow = 'hidden';
     
@@ -1917,7 +1978,7 @@ function updateSOCStats(socStats) {
     const statsTitle = document.createElement('h3');
     statsTitle.textContent = 'SOC Statistics';
     statsTitle.style.margin = '0 0 10px 0';
-    statsTitle.style.color = '#333';
+    statsTitle.style.color = 'var(--heading)';
     statsSection.appendChild(statsTitle);
     
     // Create a card container for count stats - make it more compact
@@ -1928,29 +1989,24 @@ function updateSOCStats(socStats) {
     
     // Define stats with label, value, and icon
     const stats = [
-        { label: 'Total Sessions', value: socStats.total_sessions, icon: '📊', color: '#3498db' },
-        { label: 'Failed Sessions', value: socStats.failed_sessions, icon: '❌', color: '#e74c3c' },
-        { label: 'End SoC > 80%', value: socStats.above_80_count, icon: '🔋', color: '#27ae60' },
-        { label: 'End SoC = 80%', value: socStats.exactly_80_count, icon: '⚖️', color: '#f39c12' },
-        { label: 'End SoC < 80%', value: socStats.below_80_count, icon: '⚠️', color: '#e67e22' },
-        { label: 'End SoC = 100%', value: socStats.exactly_100_count, icon: '✅', color: '#2ecc71' }
+        { label: 'Total Sessions', value: socStats.total_sessions, icon: 'chart', color: '#3498db' },
+        { label: 'Failed Sessions', value: socStats.failed_sessions, icon: 'cross', color: '#e74c3c' },
+        { label: 'End SoC > 80%', value: socStats.above_80_count, icon: 'battery', color: '#27ae60' },
+        { label: 'End SoC = 80%', value: socStats.exactly_80_count, icon: 'scale', color: '#f39c12' },
+        { label: 'End SoC < 80%', value: socStats.below_80_count, icon: 'alert', color: '#e67e22' },
+        { label: 'End SoC = 100%', value: socStats.exactly_100_count, icon: 'check', color: '#2ecc71' }
     ];
     
     // Create more compact styled cards for each stat
     stats.forEach(stat => {
         const card = document.createElement('div');
-        card.style.backgroundColor = '#ffffff';
-        card.style.borderRadius = '6px';
-        card.style.padding = '10px';
-        card.style.boxShadow = '0 1px 3px rgba(0,0,0,0.1)';
+        card.style.backgroundColor = 'var(--card-bg)';
+        card.style.borderRadius = 'var(--radius-sm)';
+        card.style.padding = '12px';
+        card.style.boxShadow = 'var(--shadow-sm)';
         card.style.display = 'flex';
         card.style.flexDirection = 'column';
-        card.style.transition = 'transform 0.2s';
-        card.style.border = `1px solid ${stat.color}20`;
-        
-        // Add hover effect
-        card.onmouseover = () => card.style.transform = 'translateY(-2px)';
-        card.onmouseout = () => card.style.transform = 'translateY(0)';
+        card.style.border = '1px solid var(--border)';
         
         // Create header with icon and label
         const header = document.createElement('div');
@@ -1959,14 +2015,16 @@ function updateSOCStats(socStats) {
         header.style.marginBottom = '5px';
         
         const icon = document.createElement('span');
-        icon.textContent = stat.icon;
-        icon.style.marginRight = '5px';
-        icon.style.fontSize = '16px';
+        icon.innerHTML = svgIcon(stat.icon, 16);
+        icon.style.color = stat.color;
+        icon.style.marginRight = '8px';
+        icon.style.display = 'inline-flex';
+        icon.style.alignItems = 'center';
         
         const label = document.createElement('span');
         label.textContent = stat.label;
-        label.style.fontWeight = 'bold';
-        label.style.color = '#555555';
+        label.style.fontWeight = '600';
+        label.style.color = 'var(--muted)';
         label.style.fontSize = '12px';
         
         header.appendChild(icon);
@@ -1998,7 +2056,7 @@ function updateSOCStats(socStats) {
     const summaryTitle = document.createElement('h3');
     summaryTitle.textContent = 'State of Charge Summary';
     summaryTitle.style.margin = '0 0 10px 0';
-    summaryTitle.style.color = '#333';
+    summaryTitle.style.color = 'var(--heading)';
     socAveragesSection.appendChild(summaryTitle);
     
     // Ensure percentage values exist in socStats or use default values
@@ -2421,9 +2479,9 @@ function createCombinedGauges() {
     cardContainer.style.gap = '20px';
     cardContainer.style.padding = '20px';
     cardContainer.style.height = '100%';
-    cardContainer.style.backgroundColor = '#ffffff';
-    cardContainer.style.borderRadius = '15px';
-    cardContainer.style.boxShadow = '0 5px 15px rgba(0, 0, 0, 0.05)';
+    cardContainer.style.backgroundColor = 'var(--card-bg)';
+    cardContainer.style.borderRadius = 'var(--radius)';
+    cardContainer.style.boxShadow = 'var(--shadow-sm)';
     
     // Find max values for comparison
     const maxPower = Math.max(...sessions.map(s => s.avg_power));
@@ -2437,7 +2495,7 @@ function createCombinedGauges() {
             label: "Average Grid Power",
             value: currentSession.avg_power.toFixed(1),
             unit: "kW",
-            icon: "⚡",
+            icon: "gauge",
             color: "#3498db",
             max: maxPower,
             percentOfMax: (currentSession.avg_power / maxPower) * 100
@@ -2446,7 +2504,7 @@ function createCombinedGauges() {
             label: "Cost",
             value: currentSession.cost.toFixed(2),
             unit: "€",
-            icon: "💶",
+            icon: "euro",
             color: "#2ecc71",
             max: maxCost,
             percentOfMax: (currentSession.cost / maxCost) * 100
@@ -2455,7 +2513,7 @@ function createCombinedGauges() {
             label: "Efficiency",
             value: (currentSession.efficiency * 100).toFixed(1),
             unit: "%",
-            icon: "🔋",
+            icon: "battery",
             color: "#f39c12",
             max: 100,
             percentOfMax: currentSession.efficiency * 100
@@ -2464,7 +2522,7 @@ function createCombinedGauges() {
             label: "Energy Added",
             value: currentSession.energy_added_hvb.toFixed(1),
             unit: "kWh",
-            icon: "⚡",
+            icon: "bolt",
             color: "#9b59b6",
             max: maxEnergy,
             percentOfMax: (currentSession.energy_added_hvb / maxEnergy) * 100
@@ -2473,7 +2531,7 @@ function createCombinedGauges() {
             label: "Session Time",
             value: Math.round(currentSession.session_time_minutes),
             unit: "min",
-            icon: "⏱️",
+            icon: "clock",
             color: "#e74c3c",
             max: maxTime,
             percentOfMax: (currentSession.session_time_minutes / maxTime) * 100
@@ -2497,37 +2555,26 @@ function createCombinedGauges() {
     function createMetricCard(metric) {
         const card = document.createElement('div');
         card.className = 'session-metric-card';
-        card.style.backgroundColor = '#ffffff';
-        card.style.borderRadius = '12px';
+        card.style.backgroundColor = 'var(--card-bg)';
+        card.style.borderRadius = 'var(--radius)';
+        card.style.border = '1px solid var(--border)';
         card.style.padding = '20px';
-        card.style.boxShadow = '0 4px 12px rgba(0,0,0,0.08)';
         card.style.display = 'flex';
         card.style.flexDirection = 'column';
         card.style.alignItems = 'center';
         card.style.justifyContent = 'space-between';
-        card.style.transition = 'transform 0.3s ease, box-shadow 0.3s ease';
         card.style.position = 'relative';
         card.style.overflow = 'hidden';
         
-        // Add hover effect
-        card.onmouseover = () => {
-            card.style.transform = 'translateY(-5px)';
-            card.style.boxShadow = '0 8px 20px rgba(0,0,0,0.12)';
-        };
-        card.onmouseout = () => {
-            card.style.transform = 'translateY(0)';
-            card.style.boxShadow = '0 4px 12px rgba(0,0,0,0.08)';
-        };
-        
         // Create icon
         const icon = document.createElement('div');
-        icon.textContent = metric.icon;
-        icon.style.fontSize = '28px';
-        icon.style.marginBottom = '10px';
-        icon.style.backgroundColor = `${metric.color}15`; // Light background based on color
-        icon.style.width = '50px';
-        icon.style.height = '50px';
-        icon.style.borderRadius = '50%';
+        icon.innerHTML = svgIcon(metric.icon, 20);
+        icon.style.color = 'var(--accent)';
+        icon.style.marginBottom = '12px';
+        icon.style.backgroundColor = 'color-mix(in srgb, var(--accent) 12%, transparent)';
+        icon.style.width = '40px';
+        icon.style.height = '40px';
+        icon.style.borderRadius = 'var(--radius-sm)';
         icon.style.display = 'flex';
         icon.style.justifyContent = 'center';
         icon.style.alignItems = 'center';
@@ -2536,7 +2583,7 @@ function createCombinedGauges() {
         const label = document.createElement('div');
         label.textContent = metric.label;
         label.style.fontSize = '14px';
-        label.style.color = '#666';
+        label.style.color = 'var(--muted)';
         label.style.marginBottom = '15px';
         label.style.textAlign = 'center';
         
@@ -2550,14 +2597,15 @@ function createCombinedGauges() {
         const value = document.createElement('div');
         value.textContent = metric.value;
         value.style.fontSize = '32px';
-        value.style.fontWeight = 'bold';
-        value.style.color = metric.color;
+        value.style.fontWeight = '700';
+        value.style.color = 'var(--heading)';
+        value.style.letterSpacing = '-0.02em';
         
         // Create unit
         const unit = document.createElement('div');
         unit.textContent = metric.unit;
         unit.style.fontSize = '14px';
-        unit.style.color = '#999';
+        unit.style.color = 'var(--muted)';
         unit.style.marginLeft = '5px';
         
         valueContainer.appendChild(value);
@@ -2567,7 +2615,7 @@ function createCombinedGauges() {
         const progressContainer = document.createElement('div');
         progressContainer.style.width = '100%';
         progressContainer.style.height = '6px';
-        progressContainer.style.backgroundColor = '#f0f0f0';
+        progressContainer.style.backgroundColor = 'var(--track)';
         progressContainer.style.borderRadius = '3px';
         progressContainer.style.overflow = 'hidden';
         progressContainer.style.marginTop = '5px';
@@ -2576,7 +2624,7 @@ function createCombinedGauges() {
         const progress = document.createElement('div');
         progress.style.width = `${metric.percentOfMax}%`;
         progress.style.height = '100%';
-        progress.style.backgroundColor = metric.color;
+        progress.style.backgroundColor = 'var(--accent)';
         progress.style.borderRadius = '3px';
         progress.style.transition = 'width 1s ease';
         
@@ -2586,7 +2634,7 @@ function createCombinedGauges() {
         const comparison = document.createElement('div');
         comparison.textContent = `${metric.percentOfMax.toFixed(0)}% of max (${metric.max.toFixed(1)} ${metric.unit})`;
         comparison.style.fontSize = '10px';
-        comparison.style.color = '#999';
+        comparison.style.color = 'var(--muted)';
         comparison.style.marginTop = '5px';
         comparison.style.textAlign = 'right';
         
@@ -2604,23 +2652,13 @@ function createCombinedGauges() {
     function createAdditionalInfoCard() {
         const card = document.createElement('div');
         card.className = 'session-info-card';
-        card.style.backgroundColor = '#ffffff';
-        card.style.borderRadius = '12px';
+        card.style.backgroundColor = 'var(--card-bg)';
+        card.style.borderRadius = 'var(--radius)';
+        card.style.border = '1px solid var(--border)';
         card.style.padding = '20px';
-        card.style.boxShadow = '0 4px 12px rgba(0,0,0,0.08)';
+        card.style.boxShadow = 'var(--shadow-sm)';
         card.style.display = 'flex';
         card.style.flexDirection = 'column';
-        card.style.transition = 'transform 0.3s ease, box-shadow 0.3s ease';
-        
-        // Add hover effect
-        card.onmouseover = () => {
-            card.style.transform = 'translateY(-5px)';
-            card.style.boxShadow = '0 8px 20px rgba(0,0,0,0.12)';
-        };
-        card.onmouseout = () => {
-            card.style.transform = 'translateY(0)';
-            card.style.boxShadow = '0 4px 12px rgba(0,0,0,0.08)';
-        };
         
         // Create header
         const header = document.createElement('div');
@@ -2629,15 +2667,17 @@ function createCombinedGauges() {
         header.style.marginBottom = '15px';
         
         const icon = document.createElement('span');
-        icon.textContent = '📊';
-        icon.style.fontSize = '24px';
+        icon.innerHTML = svgIcon('chart', 20);
+        icon.style.color = 'var(--accent)';
         icon.style.marginRight = '10px';
+        icon.style.display = 'inline-flex';
+        icon.style.alignItems = 'center';
         
         const title = document.createElement('h4');
         title.textContent = 'Session Details';
         title.style.margin = '0';
         title.style.fontSize = '16px';
-        title.style.color = '#444';
+        title.style.color = 'var(--text)';
         
         header.appendChild(icon);
         header.appendChild(title);
@@ -2688,7 +2728,7 @@ function createCombinedGauges() {
             const labelCell = document.createElement('td');
             labelCell.textContent = item.label;
             labelCell.style.padding = '5px 0';
-            labelCell.style.color = '#666';
+            labelCell.style.color = 'var(--muted)';
             labelCell.style.fontSize = '14px';
             
             const valueCell = document.createElement('td');
@@ -2696,7 +2736,7 @@ function createCombinedGauges() {
             valueCell.style.padding = '5px 0';
             valueCell.style.textAlign = 'right';
             valueCell.style.fontWeight = '500';
-            valueCell.style.color = '#333';
+            valueCell.style.color = 'var(--text)';
             valueCell.style.fontSize = '14px';
             
             row.appendChild(labelCell);
@@ -2748,12 +2788,12 @@ function createCombinedGauges() {
         const socLabel = document.createElement('div');
         socLabel.textContent = 'Charge Progress';
         socLabel.style.fontSize = '14px';
-        socLabel.style.color = '#666';
+        socLabel.style.color = 'var(--muted)';
         socLabel.style.marginBottom = '5px';
         
         const socBarContainer = document.createElement('div');
         socBarContainer.style.height = '20px';
-        socBarContainer.style.backgroundColor = '#f0f0f0';
+        socBarContainer.style.backgroundColor = 'var(--track)';
         socBarContainer.style.borderRadius = '10px';
         socBarContainer.style.position = 'relative';
         socBarContainer.style.overflow = 'hidden';

--- a/go-rewrite/static/js/stats.js
+++ b/go-rewrite/static/js/stats.js
@@ -1,43 +1,71 @@
 // BMW Tools - Anonymous Statistics Dashboard
 
-// Plotly template for better styling (copied from main app.js)
-const plotlyTemplate = {
-    layout: {
-        paper_bgcolor: '#ffffff',
-        plot_bgcolor: '#ffffff',
-        font: {
-            family: 'SF Pro Display, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
-            color: '#444',
-            size: 12
-        },
-        title: {
-            font: {
-                family: 'SF Pro Display, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
-                size: 18,
-                color: '#333'
-            }
-        },
-        colorway: ['#3498db', '#2ecc71', '#f39c12', '#e74c3c', '#9b59b6', '#1abc9c', '#34495e', '#7f8c8d', '#d35400', '#c0392b'],
-        legend: {
-            bgcolor: '#ffffff',
-            bordercolor: '#f0f0f0',
-            borderwidth: 1,
-            font: {
-                family: 'SF Pro Display, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
-                size: 12,
-                color: '#555'
-            }
-        },
-        xaxis: {
-            gridcolor: '#f0f0f0',
-            zerolinecolor: '#e0e0e0'
-        },
-        yaxis: {
-            gridcolor: '#f0f0f0',
-            zerolinecolor: '#e0e0e0'
-        }
+const PLOTLY_FONT_FAMILY = 'SF Pro Display, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif';
+
+// Read a CSS custom property (with a fallback) for use inside Plotly layout
+// objects, which cannot resolve CSS var() references themselves.
+function themeColor(name, fallback) {
+    try {
+        const v = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+        return v || fallback;
+    } catch (e) {
+        return fallback;
     }
-};
+}
+
+// Build a Plotly template that derives its colours from the active theme so the
+// charts re-skin correctly when the user toggles light/dark mode.
+function buildPlotlyTemplate() {
+    const themeLayout = (window.BMWTheme && window.BMWTheme.plotlyLayout)
+        ? window.BMWTheme.plotlyLayout()
+        : {};
+    const text = themeColor('--text', '#2c3e50');
+    const heading = themeColor('--heading', '#2c3e50');
+    const muted = themeColor('--muted', '#6b7785');
+    const grid = themeColor('--track', '#f0f0f0');
+    const border = themeColor('--border', '#e0e0e0');
+    const cardBg = themeColor('--card-bg', '#ffffff');
+    return {
+        layout: {
+            paper_bgcolor: cardBg,
+            plot_bgcolor: cardBg,
+            font: {
+                family: PLOTLY_FONT_FAMILY,
+                color: text,
+                size: 12
+            },
+            title: {
+                font: {
+                    family: PLOTLY_FONT_FAMILY,
+                    size: 18,
+                    color: heading
+                }
+            },
+            colorway: ['#3498db', '#2ecc71', '#f39c12', '#e74c3c', '#9b59b6', '#1abc9c', '#34495e', '#7f8c8d', '#d35400', '#c0392b'],
+            legend: {
+                bgcolor: cardBg,
+                bordercolor: border,
+                borderwidth: 1,
+                font: {
+                    family: PLOTLY_FONT_FAMILY,
+                    size: 12,
+                    color: muted
+                }
+            },
+            xaxis: {
+                gridcolor: grid,
+                zerolinecolor: border
+            },
+            yaxis: {
+                gridcolor: grid,
+                zerolinecolor: border
+            },
+            ...themeLayout
+        }
+    };
+}
+
+let plotlyTemplate = buildPlotlyTemplate();
 
 console.log('stats.js loaded - ' + new Date().toISOString());
 
@@ -61,6 +89,7 @@ async function initStatsDashboard() {
         }
         
         const data = await response.json();
+        window.__statsData = data;
         
         // Update the UI with the data
         updateGlobalStats(data.global_stats, data.soc_stats);
@@ -262,7 +291,7 @@ function createProviderFailureChart(providers) {
         textposition: 'outside',
         textfont: {
             size: 11,
-            color: '#333'
+            color: themeColor('--text', '#2c3e50')
         },
         hovertemplate: '<b>%{x}</b><br>Failure Rate: %{y:.1f}%<br>Failed: %{text}<extra></extra>',
         width: 0.6 // Make bars narrower
@@ -272,8 +301,7 @@ function createProviderFailureChart(providers) {
         title: {
             text: 'Charging Failure Rates by Provider',
             font: { size: 20 }
-        },
-        xaxis: {
+        },        xaxis: {
             title: 'Provider',
             tickangle: -45,
             tickfont: {
@@ -347,7 +375,7 @@ function createSessionOutcomesChart(globalStats) {
         textposition: 'outside',
         textfont: {
             size: 14,
-            color: '#333'
+            color: themeColor('--text', '#2c3e50')
         },
         hoverinfo: 'label+value+percent',
         hole: 0.4, // Create a donut chart for better visual appeal
@@ -452,7 +480,7 @@ function createEnergyByProviderChart(providers) {
         textposition: 'outside',
         textfont: {
             size: 11,
-            color: '#333'
+            color: themeColor('--text', '#2c3e50')
         },
         hovertemplate: '<b>%{x}</b><br>Total Energy: %{y:.1f} kWh<br>Sessions: %{text}<extra></extra>',
         width: 0.6 // Make bars narrower
@@ -518,3 +546,15 @@ function showErrorMessage(message) {
 }
 
 // We removed the formatProviderName function as we want to display the original provider names exactly as stored in the database
+
+// Re-skin the Plotly charts when the user toggles light/dark mode. The template
+// is rebuilt from the now-current CSS tokens and the charts are re-rendered from
+// the cached stats payload.
+window.addEventListener('bmwthemechange', function() {
+    plotlyTemplate = buildPlotlyTemplate();
+    const data = window.__statsData;
+    if (!data) return;
+    createProviderFailureChart(data.providers);
+    createSessionOutcomesChart(data.global_stats);
+    createEnergyByProviderChart(data.providers);
+});

--- a/go-rewrite/static/js/theme.js
+++ b/go-rewrite/static/js/theme.js
@@ -1,0 +1,73 @@
+// Shared theme controller for BMW CarData dashboard pages.
+// Owns the dark/light toggle button, persistence, and a Plotly layout helper
+// derived from the active CSS theme tokens. Pages listen for 'bmwthemechange'
+// to re-render their Plotly charts with the new palette.
+(function () {
+    const root = document.documentElement;
+
+    function current() {
+        return root.getAttribute('data-theme') === 'dark' ? 'dark' : 'light';
+    }
+
+    function cssVar(name, fallback) {
+        const v = getComputedStyle(root).getPropertyValue(name).trim();
+        return v || fallback;
+    }
+
+    // Returns a Plotly layout fragment that matches the current theme.
+    function plotlyLayout() {
+        const surface = cssVar('--card-bg', '#ffffff');
+        const text = cssVar('--text', '#2c3e50');
+        const muted = cssVar('--muted', '#6b7785');
+        const grid = cssVar('--track', '#eef1f4');
+        const border = cssVar('--border', '#e6e9ee');
+        return {
+            paper_bgcolor: surface,
+            plot_bgcolor: surface,
+            font: { color: muted },
+            title: { font: { color: text } },
+            legend: { bgcolor: surface, bordercolor: border, font: { color: muted } },
+            xaxis: {
+                gridcolor: grid,
+                zerolinecolor: border,
+                linecolor: border,
+                tickfont: { color: muted },
+                title: { font: { color: muted } }
+            },
+            yaxis: {
+                gridcolor: grid,
+                zerolinecolor: border,
+                linecolor: border,
+                tickfont: { color: muted },
+                title: { font: { color: muted } }
+            }
+        };
+    }
+
+    window.BMWTheme = {
+        current: current,
+        cssVar: cssVar,
+        plotlyLayout: plotlyLayout
+    };
+
+    function setTheme(theme) {
+        root.setAttribute('data-theme', theme);
+        try { localStorage.setItem('bmw-theme', theme); } catch (e) { /* ignore */ }
+        window.dispatchEvent(new CustomEvent('bmwthemechange', { detail: { theme: theme } }));
+    }
+
+    function wire() {
+        const btn = document.getElementById('theme-toggle');
+        if (btn) {
+            btn.addEventListener('click', function () {
+                setTheme(current() === 'dark' ? 'light' : 'dark');
+            });
+        }
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', wire);
+    } else {
+        wire();
+    }
+})();

--- a/go-rewrite/static/stats.html
+++ b/go-rewrite/static/stats.html
@@ -4,6 +4,19 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>BMW CarData - Anonymous Charging Statistics</title>
+    <!-- Set theme before any paint to avoid flash of incorrect theme -->
+    <script>
+        (function() {
+            try {
+                var saved = localStorage.getItem('bmw-theme');
+                var theme = saved || (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+                document.documentElement.setAttribute('data-theme', theme);
+            } catch (e) {
+                document.documentElement.setAttribute('data-theme', 'light');
+            }
+        })();
+    </script>
+    <script src="/static/js/theme.js"></script>
     <!-- CSS will be loaded dynamically with cache busting -->
     <!-- Include Plotly.js -->
     <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
@@ -47,17 +60,18 @@
     <style>
         /* Additional styles specific to the statistics page */
         .stats-card {
-            background-color: white;
-            border-radius: 12px;
+            background-color: var(--card-bg);
+            border: 1px solid var(--border);
+            border-radius: 14px;
             padding: 20px;
             margin-bottom: 20px;
-            box-shadow: 0 4px 12px rgba(0,0,0,0.08);
-            transition: transform 0.3s ease, box-shadow 0.3s ease;
+            box-shadow: var(--shadow-sm);
+            transition: transform 0.25s ease, box-shadow 0.25s ease;
         }
         
         .stats-card:hover {
-            transform: translateY(-5px);
-            box-shadow: 0 8px 20px rgba(0,0,0,0.12);
+            transform: translateY(-4px);
+            box-shadow: var(--shadow-md);
         }
         
         .stats-header {
@@ -66,7 +80,7 @@
             align-items: center;
             margin-bottom: 15px;
             padding-bottom: 10px;
-            border-bottom: 1px solid #f0f0f0;
+            border-bottom: 1px solid var(--border);
         }
         
         .stats-count {
@@ -74,11 +88,12 @@
             font-weight: bold;
             margin-top: 10px;
             margin-bottom: 5px;
+            color: var(--heading);
         }
         
         .stats-label {
             font-size: 14px;
-            color: #666;
+            color: var(--muted);
         }
         
         .stats-grid {
@@ -91,22 +106,23 @@
             width: 100%;
             border-collapse: collapse;
             margin-top: 20px;
+            color: var(--text);
         }
         
         .stats-table th, .stats-table td {
             padding: 10px;
             text-align: left;
-            border-bottom: 1px solid #f0f0f0;
+            border-bottom: 1px solid var(--border);
         }
         
         .stats-table th {
             font-weight: 600;
-            color: #333;
-            background-color: #f8f9fa;
+            color: var(--heading);
+            background-color: var(--surface-2);
         }
         
         .stats-table tr:hover {
-            background-color: #f8f9fa;
+            background-color: var(--surface-2);
         }
         
         .success-rate {
@@ -140,7 +156,7 @@
         
         .notice {
             text-align: center;
-            color: #666;
+            color: var(--muted);
             margin: 40px 0;
             font-style: italic;
         }
@@ -149,6 +165,10 @@
 <body>
     <div class="container">
         <header>
+            <button id="theme-toggle" class="theme-toggle" type="button" aria-label="Toggle dark mode" title="Toggle dark mode">
+                <span class="icon-moon" aria-hidden="true">🌙</span>
+                <span class="icon-sun" aria-hidden="true">☀️</span>
+            </button>
             <h1>BMW CarData - Anonymous Charging Statistics</h1>
             <nav class="main-nav">
                 <ul>


### PR DESCRIPTION
## Summary

A frontend-only redesign of the dashboard (no Go/server changes). Adds a full light/dark theme, a more professional visual language, and fixes a few layout "fit" issues.

## Changes

**Theming**
- New `static/js/theme.js`: light/dark theme system with toggle, `localStorage` persistence, `prefers-color-scheme` default, and a FOUC guard. Exposes `window.BMWTheme` (`current()`, `cssVar()`, `plotlyLayout()`) and dispatches a `bmwthemechange` event.
- `styles.css`: design-token system (`:root` light tokens + `html[data-theme="dark"]` overrides), flatter surfaces, tightened radii, lighter shadows, single-row app bar.
- `nav.css`: rewritten to understated segmented tabs (removed the gradient pill).
- `stats.html` / `battery.html` inline styles tokenized for dark mode.

**Professional polish**
- Replaced emoji card icons with an inline SVG line-icon set.
- Unified accent/heading color scheme; removed gradient text and playful hover lifts.

**Charts**
- All Plotly charts are now theme-aware — the template is rebuilt at render time so charts render correctly in dark mode (fixes white chart backgrounds in dark mode), and re-render on theme toggle.

**Layout fit fixes**
- Left-aligned the *Total Energy Consumption* and *Power Consumption* titles, moved the legend below the chart, and disabled the cluttering Plotly modebar on the summary charts (it was overlapping the titles).
- `.gauge-chart`: `height` → `min-height` (+ `min-width: 0`) so the appended info cards no longer clip in the desktop side-by-side row layout.

## Testing
- `node --check` passes for `app.js` and `stats.js`.
- Verified light + dark mode and theme toggle across Dashboard, Stats, and Battery pages.
- Verified the gauge row no longer clips its content in the side-by-side (desktop) layout.

## Notes
- All element IDs that the JS depends on are preserved.
- No secrets, credentials, `.db`, `.env`, or key files are included — verified by scanning the diff.
